### PR TITLE
Use zipalign to avoid errors with Android R+

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 ## Usage
 
 ### XML-only
+
 `py makeDebuggable.py xml [file in] [file out]`
 
 This takes an existing AndroidManifest.xml file and outputs a version where debuggable is set to true.
 
 ### APK
+
 `py makeDebuggable.py apk [file in] [file out] [keystore] [key alias]`
 
-_This command requires apksigner present in PATH. You can get it by installing `platform-tools` using [sdkmanager](https://developer.android.com/studio/command-line/sdkmanager)._
+_This command requires zipalign and apksigner present in PATH. You can get them by installing `platform-tools` using [sdkmanager](https://developer.android.com/studio/command-line/sdkmanager)._
 
 This reads an existing APK file and outputs a version where debuggable is set to true. The last two arguments are for apksigner and define the JKS keystore location and the key alias for re-signing the apk.
 


### PR DESCRIPTION
This PR adds usage of zipalign to avoid errors with Android R+ (>= 30)

[Targeting R+ (version 30 and above) requires the resources.arsc of installed APKs to be stored uncompressed and aligned on a 4-byte boundary](https://stackoverflow.com/questions/69667830/targeting-r-version-30-and-above-requires-the-resources-arsc-of-installed-apk)