### PR TITLE
Add in password 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ This takes an existing AndroidManifest.xml file and outputs a version where debu
 
 ### APK
 
-`py makeDebuggable.py apk [file in] [file out] [keystore] [key alias]`
+`Usage: apk [fileIn] [fileOut] [keystore] [key alias] [keystore password]`
 
 _This command requires zipalign and apksigner present in PATH. You can get them by installing `platform-tools` using [sdkmanager](https://developer.android.com/studio/command-line/sdkmanager)._
 
-This reads an existing APK file and outputs a version where debuggable is set to true. The last two arguments are for apksigner and define the JKS keystore location and the key alias for re-signing the apk.
+This reads an existing APK file and outputs a version where debuggable is set to true. The last two arguments are for apksigner and define the JKS keystore location and the key alias for re-signing the apk and the password for the keystore.
 
 ## Notes on other tools
 


### PR DESCRIPTION
This is a great script! It does what ApkTool does not do in allowing work with split apks. I added in the ability to have the password for the keystore entered in the apk path. This removed the need to enter it at every split apk signing. I also added the she·bang to the top for easier usage if anyone wants to use it that way.